### PR TITLE
Allow bdist_rpm to work

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ desc, _sep, long_desc = rfc3987.__doc__.partition('.')
 
 setup(name='rfc3987',
       version= rfc3987.__version__,
-      description=desc,
+      description=desc.strip(),
       long_description=long_desc.lstrip().format(**rfc3987.__dict__),
       author='Daniel Gerber',
       author_email='daniel.g.gerber@gmail.com',


### PR DESCRIPTION
./setup.py bdist_rpm currently fails with a bad Summary line, as the description string is prefixed with a \n.

Stripping the string down to a single line solves this, without breaking anything else.