### PR TITLE
Fix deprecation warnings for real

### DIFF
--- a/rfc3987.py
+++ b/rfc3987.py
@@ -344,7 +344,7 @@ patterns = format_patterns(**DEFAULT_GROUP_NAMES)
 
 
 def _interpret_unicode_escapes(string):
-    return string.encode('ascii').decode('unicode-escape')
+    return string.encode('ascii').decode('raw-unicode-escape')
 
 patterns_no_names = format_patterns()
 


### PR DESCRIPTION
Recent fix in 4fbe4862109f17b36406c7e90b7fc9fe0c909479 doesn't get rid of deprecation warnings for me. I still see:

```
rfc3987.py:347: DeprecationWarning: invalid escape sequence '\]'
  return string.encode('ascii').decode('unicode-escape')
```

I'm posting a small change which should deal with the issue. (See https://docs.python.org/3/library/codecs.html#text-encodings)